### PR TITLE
Add bottom navigation with icons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,14 @@
-import { AppBar, Toolbar, Typography, Button, CssBaseline } from '@mui/material'
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  Button,
+  CssBaseline,
+} from '@mui/material'
+import BottomNav from './components/BottomNav'
 
 function App() {
+
   return (
     <>
       <CssBaseline />
@@ -12,6 +20,7 @@ function App() {
           <Button color="inherit">Log in</Button>
         </Toolbar>
       </AppBar>
+      <BottomNav />
     </>
   )
 }

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import {
+  BottomNavigation,
+  BottomNavigationAction,
+  Paper,
+} from '@mui/material'
+import HomeIcon from '@mui/icons-material/Home'
+import ExploreIcon from '@mui/icons-material/TravelExplore'
+import SettingsIcon from '@mui/icons-material/Settings'
+
+function BottomNav() {
+  const [value, setValue] = useState(0)
+
+  return (
+    <Paper sx={{ position: 'fixed', bottom: 0, left: 0, right: 0 }} elevation={3}>
+      <BottomNavigation
+        showLabels
+        value={value}
+        onChange={(_event, newValue) => setValue(newValue)}
+      >
+        <BottomNavigationAction label="Home" icon={<HomeIcon />} />
+        <BottomNavigationAction label="Explore" icon={<ExploreIcon />} />
+        <BottomNavigationAction label="Settings" icon={<SettingsIcon />} />
+      </BottomNavigation>
+    </Paper>
+  )
+}
+
+export default BottomNav


### PR DESCRIPTION
## Summary
- add Material UI bottom navigation with Home, Explore and Settings sections
- refactor bottom navigation into its own component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e9042563c832f91a63472bb6801f8